### PR TITLE
Chronos now belongs to the Mesos organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Spin up your [Mesos](http://mesos.apache.org) Cluster with [Vagrant](http://www.vagrantup.com)! (Both Virtualbox and AWS are supported.)
 
-This spins up Mesos 0.20.1 cluster and also spins up a framework server node in which [Marathon](https://github.com/mesosphere/marathon) (0.7.1) and [Chronos](http://github.com/mesosphere/chronos) (2.1.0) are runinng.  This means you can build your own __Mesos+Marathon+Chronos+Docker__ PaaS with `vagrant up`!!  Marathon works as distributed `init.d` and Chronos works as distributed `cron`!!  _If you wanted to deploy docker containers, please refer to the chapter "Deploy Docker Container with Marathon" in [thig blog entry](http://frankhinek.com/deploy-docker-containers-on-mesos-0-20/)._
+This spins up Mesos 0.20.1 cluster and also spins up a framework server node in which [Marathon](https://github.com/mesosphere/marathon) (0.7.1) and [Chronos](http://github.com/mesos/chronos) (2.1.0) are runinng.  This means you can build your own __Mesos+Marathon+Chronos+Docker__ PaaS with `vagrant up`!!  Marathon works as distributed `init.d` and Chronos works as distributed `cron`!!  _If you wanted to deploy docker containers, please refer to the chapter "Deploy Docker Container with Marathon" in [thig blog entry](http://frankhinek.com/deploy-docker-containers-on-mesos-0-20/)._
 
 * Using VirtualBox
 	* [Mesos Standalone on VirtualBox](#svb)
@@ -44,7 +44,7 @@ After box is up, you can see services running at:
 
 * Mesos web UI on: <http://192.168.33.10:5050>
 * [Marathon](https://github.com/mesosphere/marathon) web UI on: <http://192.168.33.10:8080>
-* [Chronos](https://github.com/mesosphere/chronos) web UI on: <http://192.168.33.10:8081>
+* [Chronos](https://github.com/mesos/chronos) web UI on: <http://192.168.33.10:8081>
 
 <a name="sec2"></a>
 Mesos Standalone on EC2
@@ -80,7 +80,7 @@ Mesos Standalone on EC2
 
    * Mesos web UI on: `http://#_public_dns_of_the_VM_#:5050`
    * [Marathon](https://github.com/mesosphere/marathon) web UI on: `http://#_public_dns_of_the_VM_#:8080`
-   * [Chronos](https://github.com/mesosphere/chronos) web UI on: `http://#_public_dns_of_the_VM_#:8081`
+   * [Chronos](https://github.com/mesos/chronos) web UI on: `http://#_public_dns_of_the_VM_#:8081`
 
 
 	_Tips: you can get public dns of the vm by:_
@@ -136,7 +136,7 @@ At default setting, after all the boxes are up, you can see services running at:
 
 * Mesos web UI on: <http://172.31.1.11:5050>
 * [Marathon](https://github.com/mesosphere/marathon) web UI on: <http://172.31.3.11:8080>
-* [Chronos](https://github.com/mesosphere/chronos) web UI on: <http://172.31.3.11:8081>
+* [Chronos](https://github.com/mesos/chronos) web UI on: <http://172.31.3.11:8081>
 
 #### Destroy Cluster
 this operations all VM instances forming the cluster.


### PR DESCRIPTION
Chronos has moved to the Mesos organisation. Fix links.